### PR TITLE
foostan CRKBD Blok config fix

### DIFF
--- a/keyboards/Foostan-CRKBD-blok-L/kb.py
+++ b/keyboards/Foostan-CRKBD-blok-L/kb.py
@@ -3,9 +3,6 @@ import board
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.scanners import DiodeOrientation
 
-
-
-
 class KMKKeyboard(_KMKKeyboard):
     col_pins = (
         board.GP29,

--- a/keyboards/Foostan-CRKBD-blok-L/main.py
+++ b/keyboards/Foostan-CRKBD-blok-L/main.py
@@ -8,6 +8,8 @@ import supervisor
 from kmk.extensions.peg_oled_Display import Oled,OledDisplayMode,OledReactionType,OledData
 from kmk.extensions.peg_rgb_matrix import Rgb_matrix
 from kmk.modules.split import Split, SplitSide, SplitType
+from kmk.extensions.media_keys import MediaKeys
+keyboard.extensions.append(MediaKeys())
 keyboard = KMKKeyboard()
 modtap = ModTap()
 layers_ext = Layers()

--- a/keyboards/Foostan-CRKBD-blok-R/kb.py
+++ b/keyboards/Foostan-CRKBD-blok-R/kb.py
@@ -3,8 +3,6 @@ import board
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.scanners import DiodeOrientation
 
-
-
 class KMKKeyboard(_KMKKeyboard):
     col_pins = (
         board.GP29,
@@ -17,9 +15,8 @@ class KMKKeyboard(_KMKKeyboard):
     row_pins = (board.GP04, board.GP05, board.GP06, board.GP07)
     diode_orientation = DiodeOrientation.COLUMNS
     data_pin = board.RX
-
     i2c = board.I2C
-
+    rgb_pixel_pin = board.TX
     SCL=board.SCL
     SDA=board.SDA
     led_key_pos = [24,23,18,17,10,9,36,37,44,45,50,51,

--- a/keyboards/Foostan-CRKBD-blok-R/kb.py
+++ b/keyboards/Foostan-CRKBD-blok-R/kb.py
@@ -15,8 +15,8 @@ class KMKKeyboard(_KMKKeyboard):
     row_pins = (board.GP04, board.GP05, board.GP06, board.GP07)
     diode_orientation = DiodeOrientation.COLUMNS
     data_pin = board.RX
-    i2c = board.I2C
     rgb_pixel_pin = board.TX
+    i2c = board.I2C
     SCL=board.SCL
     SDA=board.SDA
     led_key_pos = [24,23,18,17,10,9,36,37,44,45,50,51,

--- a/keyboards/Foostan-CRKBD-blok-R/main.py
+++ b/keyboards/Foostan-CRKBD-blok-R/main.py
@@ -8,6 +8,8 @@ import supervisor
 from kmk.extensions.peg_oled_Display import Oled,OledDisplayMode,OledReactionType,OledData
 from kmk.extensions.peg_rgb_matrix import Rgb_matrix
 from kmk.modules.split import Split, SplitSide, SplitType
+from kmk.extensions.media_keys import MediaKeys
+keyboard.extensions.append(MediaKeys())
 keyboard = KMKKeyboard()
 modtap = ModTap()
 layers_ext = Layers()


### PR DESCRIPTION
Fixed Media Keys library missing.
Fixed configuration option required for R keyboard LEDs